### PR TITLE
Fix passigng of hash arguments

### DIFF
--- a/lib/active_storage_variant/attached.rb
+++ b/lib/active_storage_variant/attached.rb
@@ -3,13 +3,13 @@ module ActiveStorageVariant
     extend ActiveSupport::Concern
 
     class_methods do
-      def has_one_attached(name, *arg)
+      def has_one_attached(name, **arg)
         super
         reflection = self.reflect_on_attachment(name)
         yield reflection if block_given?
       end
 
-      def has_many_attached(name, *arg)
+      def has_many_attached(name, **arg)
         super
         reflection = self.reflect_on_attachment(name)
         yield reflection if block_given?


### PR DESCRIPTION
The current interface of has_one_attached and has_many_attached was not compatible with the rails interface as the latter one uses hash arguments instead of positional arguments. Therefore the argumente need to be collected as **args and not *args for being forwarded to the original method